### PR TITLE
Python version must match noetic's requirement per OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,23 @@ Welcome to RoboStack, which tightly couples ROS with Conda, a cross-platform, la
 
 Note: Make sure to _not_ install the ROS packages (in particular the `ros-noetic-catkin` package) in your base environment as this leads to issues down the track.
 
+On MacOS:
+```
+conda create --name robostackenv PYTHON=3.8
+```
+
+On Windows:
+```
+conda create --name robostackenv PYTHON=3.6
+```
+
+On Linux:
 ```
 conda create --name robostackenv
+```
+
+Then, for all OSes:
+```
 conda activate robostackenv
 conda config --append channels defaults
 conda config --add channels conda-forge

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ conda create --name robostackenv PYTHON=3.6
 
 On Linux:
 ```
-conda create --name robostackenv
+conda create --name robostackenv PYTHON=3.8
 ```
 
 Then, for all OSes:


### PR DESCRIPTION
On Windows, the line `mamba install ros-noetic-desktop` attempts to install Python 3.6, but fails. On MacOS, it attempts to install 3.8, but fails. The errors are similar. On Mac, it look like: `Problem: package ros-noetic-desktop-1.5.0-py38h143cb38_3 requires python 3.8.*, but none of the providers can be installed`

The issue is resolved by creating the conda environment with the required version of Python 3.