### PR TITLE
Clarify that command prompt is the only shell supported on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ conda activate robostackenv
 
 [Here](https://anaconda.org/search?q=ros-noetic) is a list of available packages.
 
+**Note: at the moment on Windows only the Command Prompt terminal is supported, while Powershell is not supported.**
+
 ## Reporting issues
 Feel free to open issues in this repository's [issue tracker](https://github.com/RoboStack/ros-noetic/issues) (please check whether your problem is already listed there before opening a new issue) or come around on [Gitter](https://gitter.im/RoboStack/Lobby) to have a chat / ask questions. Please note that this repository is _not an official distribution of ROS_ and relies on volunteers. It is further highly experimental - unfortunately things might not work immediately out-of-the-box, although we try our best.
 


### PR DESCRIPTION
Not sure if there are any other ideas to present this information, but I think it should be clarified as trying to use PowerShell on Windows is a common failure mode for users.