### PR TITLE
Fix #103

### DIFF
--- a/additional_recipes/ros-distro-mutex/recipe.yaml
+++ b/additional_recipes/ros-distro-mutex/recipe.yaml
@@ -29,7 +29,7 @@ requirements:
   # values here should be applied from run_exports!
   # if the upstream package does not have run_exports
   # please change it in the conda_build_config.yaml!
-  run_constrained:
+  run:
     - boost-cpp 1.74
     - log4cxx 0.11
     - pcl 1.11


### PR DESCRIPTION
Locally tested - with this change, the package properly exports the dependencies:
```yaml
  "depends": [
    "boost-cpp 1.74.*",
    "gazebo 11.*",
    "log4cxx 0.11.*",
    "ogre 1.10.12*",
    "opencv 4.5.*",
    "pcl 1.11.*",
    "poco 1.10.*"
  ],
```