### PR TITLE
Add REQUIRE_OPENGL to libopencv-dev deps

### DIFF
--- a/robostack.yaml
+++ b/robostack.yaml
@@ -269,7 +269,7 @@ libxrandr:
     linux: [xorg-libxrandr]
     osx: [xorg-libxrandr]
 libopencv-dev:  # opencv needs to be pinned, otherwise different packages might pull in different versions
-  robostack: [py-opencv 4.5, libopencv 4.5]
+  robostack: [py-opencv 4.5, libopencv 4.5, REQUIRE_OPENGL]
 python-opencv:
   robostack: [py-opencv 4.5, libopencv 4.5]
 python3-opencv:


### PR DESCRIPTION
Please have a look @wolfv @traversaro - adding the dependency doesn't hurt except for negligible added build time, so I think it's safe to go for it :)

From gitter conversation:

```
Don Venable
@venabled
05:22
Hey guys, back again after going dark for a few weeks going hard on conda-building all our stack
had a question re: boa builds of private ros packages, I'm doing something which has an opencv dependency, which is built against Qt5, and the recipe fails to build on linking against libGL.so
looking at the underlying lib (libQt5Gui.so) via ldd in the conda-build directory shows that it's resolving my system libGL.so
Don Venable
@venabled
05:40
build OS is ubuntu 18.04,libgl1-mesa-dev:amd64 is installed ,and ldd is resolving the links
using the newest boa release
Tobias Fischer
@Tobias-Fischer
05:49
I'll get back to you in an hour once I'm at work
See REQUIRE_OPENGL in https://github.com/RoboStack/vinca/blob/master/vinca/main.py
Don Venable
@venabled
05:51
Thanks, Ill keep hacking and see what's up
Tobias Fischer
@Tobias-Fischer
05:51
Try adding qt to your deps and it'll resolve magically
In the package.xml
Don Venable
@venabled
05:52
copy
Don Venable
@venabled
06:05
just for reference, I was using qt indirectly through opencv-highgui library (via opencv 4.5 conda-forge package)
not sure if we should update the conda-forge.yml file to add REQUIRE_OPENGL to that, as it seems it doesn't pick it up transitively
```