### PR TITLE
Do not modify the system state outside of the created environment in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ To get started with conda (or mamba) as package managers, you need to have a bas
 ```bash
 conda create -n robostackenv python=3.8
 conda activate robostackenv
-# this adds the conda-forge channel to your persistent configuration in ~/.condarc
-conda config --add channels conda-forge
+# this adds the conda-forge channel to the new created environment configuration 
+conda config --env --add channels conda-forge
 # and the robostack channel
-conda config --add channels robostack
+conda config --env --add channels robostack
 # it's very much advised to use strict channel priority
-conda config --set channel_priority strict
+conda config --env --set channel_priority strict
 
 # either
 conda install ros-noetic-desktop


### PR DESCRIPTION
Fix https://github.com/RoboStack/ros-noetic/issues/65 .

I originally wanted to also clarify that removing `--env` would permit to configure the `~/.condarc` instead, but after trying I think that this "quickly start" instructions should be as simple as possible.