### PR TITLE
patch: add pymongo as dep of rosbridge_library

### DIFF
--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -137,3 +137,5 @@ ifopt:
   add_host: ["ipopt"]
 tesseract_collision:
   add_build: [{"sel(osx)": "llvm-openmp"}]
+rosbridge_library:
+  add_run: ["pymongo"]


### PR DESCRIPTION
This patch should fix the issues that come from having the wrong bson module.

I added it as a Run dependency as it should be installed when running the module but not sure if that is enough? Reading [this](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html) still confuses me too much.

I'm not sure how to test this locally? Very willing to do so if anyone could explain!

closes #184