### PR TITLE
fix: remove realsense2_camera from windows build

### DIFF
--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -77,6 +77,8 @@ mesh_client:
   add_host: ["REQUIRE_OPENGL", "cgal-cpp"]
 mesh_msgs_conversions:
   add_host: ["pkg-config"]
+mbf_msgs:
+  add_host: ["numpy"]
 map_organizer:
   add_host: ["REQUIRE_OPENGL"]
 libuvc_camera:

--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -80,7 +80,6 @@ packages_select_by_deps:
   - turtlebot3
   - turtlebot3-fake
   - librealsense2
-  - realsense2_camera
   - realsense2-description
   - ur-msgs
   - rosdoc-lite
@@ -92,6 +91,7 @@ packages_select_by_deps:
   # - drone-wrapper
   # - perception_pcl
   # - velodyne_pcl
+  # - realsense2_camera
 
   # Need to build in own stage
   # - fcl


### PR DESCRIPTION
Removes `realsense2_camera` from the windows build for now. It doesn't build properly.