### PR TITLE
ros-noetic-cmake-modules, FindUUID: Do not put location of macOS SDK in UUID_INCLUDE_DIRS on macOS

### DIFF
--- a/patch/ros-noetic-cmake-modules.patch
+++ b/patch/ros-noetic-cmake-modules.patch
@@ -2,7 +2,7 @@ diff --git a/cmake/Modules/FindUUID.cmake b/cmake/Modules/FindUUID.cmake
 index 84142f4..e9d1668 100644
 --- a/cmake/Modules/FindUUID.cmake
 +++ b/cmake/Modules/FindUUID.cmake
-@@ -7,12 +7,8 @@
+@@ -7,12 +7,12 @@
  # portability
  # UUID_LIBRARIES - full path to the libraries
  if(WIN32)
@@ -14,6 +14,10 @@ index 84142f4..e9d1668 100644
 -
 +  set(UUID_LIBRARIES Rpcrt4.lib)
 +  set(UUID_FOUND true)
++elseif(APPLE)
++  set(UUID_FOUND true)
++  set(UUID_INCLUDE_DIRS "")
++  set(UUID_LIBRARIES "")
  else()
    find_path(UUID_INCLUDE_DIRS uuid/uuid.h)
    find_library(UUID_LIBRARIES NAMES uuid PATH)

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -50,6 +50,9 @@ packages_select_by_deps:
   - libmavconn
   - mavros-extras
   - mavlink
+  - cmake-modules
+  - bondcpp
+  - nodelet
   
   # ## Only limited number of packages to reduce maintainer burden
   # - catkin

--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -34,6 +34,9 @@ packages_select_by_deps:
   - roslisp
   - rqt-gui
   - catkin
+  - cmake-modules
+  - bondcpp
+  - nodelet
   # - qt-gui-cpp  # needs manual build
   # - catkin
   # - robot


### PR DESCRIPTION
Similar to https://github.com/ros/cmake_modules/pull/54/files .

Adding this patch and rebuilding `ros-noetic-cmake-modules`, `ros-noetic-bondcpp` and `ros-noetic-nodelet` should fix https://github.com/RoboStack/ros-noetic/issues/243 .