### PR TITLE
In Noetic sdformat rosdep key points to libsdformat (i.e. sdformat 9)

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -841,7 +841,7 @@ sbcl:
 screen:
   conda: [screen]
 sdformat:
-  conda: [libsdformat11]
+  conda: [libsdformat]
 sdl:
   conda: [sdl]
 sdl-image:

--- a/robostack.yaml
+++ b/robostack.yaml
@@ -824,7 +824,7 @@ sbcl:
 screen:
   robostack: [screen]
 sdformat:
-  robostack: [libsdformat11]
+  robostack: [libsdformat]
 sdl:
   robostack: [sdl]
 sdl-image:


### PR DESCRIPTION
Noetic version of https://github.com/RoboStack/ros-galactic/pull/100 .