### PR TITLE
add hector-trajecotry-server to linux

### DIFF
--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -68,6 +68,8 @@ packages_select_by_deps:
   - imu-tools
   - rqt-controller-manager
   - dynamixel-sdk
+  - hector-map-tools
+  - hector-nav-msgs
   - hector-trajectory-server
   # - desktop
   # - amcl

--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -68,6 +68,7 @@ packages_select_by_deps:
   - imu-tools
   - rqt-controller-manager
   - dynamixel-sdk
+  - hector-trajectory-server
   # - desktop
   # - amcl
   # - map-server
@@ -428,7 +429,6 @@ packages_select_by_deps:
   # - hector-pose-estimation
   # - hector-sensors-description
   # - hector-sensors-gazebo
-  # - hector-trajectory-server
   # - hfl-driver
   # - ifm3d-core
   # - image-cb-detector

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -33,6 +33,9 @@ packages_select_by_deps:
   - imu-tools
   - rqt-controller-manager
   - dynamixel-sdk
+  - hector-map-tools
+  - hector-nav-msgs
+  - hector-trajectory-server
   # ## Only limited number of packages to reduce maintainer burden
   # - desktop
   # - amcl

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -61,7 +61,10 @@ packages_select_by_deps:
   - imu-tools
   - rqt-controller-manager
   - dynamixel-sdk
-
+  - hector-map-tools
+  - hector-nav-msgs
+  - hector-trajectory-server
+  
   # ## Only limited number of packages to reduce maintainer burden
   # - catkin
   # - rviz

--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -60,6 +60,9 @@ packages_select_by_deps:
   - imu-tools
   - rqt-controller-manager
   - dynamixel-sdk
+  - hector-map-tools
+  - hector-nav-msgs
+  - hector-trajectory-server
 
   # # For jackal
   # - gazebo-dev

--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -55,6 +55,9 @@ packages_select_by_deps:
   - rosserial-msgs
   - rosserial-windows
   - rosserial-client
+  - hector-map-tools
+  - hector-nav-msgs
+  - hector-trajectory-server
 
   # # For jackal
   # - gazebo-dev


### PR DESCRIPTION
as suggested on gitter add hector trajectory server to linux.

My intuition would be to add all the hector packages to be run but I believe the goal is to keep the list small?