### PR TITLE
ros_control and ros_controllers for aarch64

### DIFF
--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -50,6 +50,9 @@ packages_select_by_deps:
   - tf2_tools
   - ros_control
   - ros_controllers
+  - cv-camera
+  - four-wheel-steering-msgs
+  - urdf-geometry-parser
   
   # ## Only limited number of packages to reduce maintainer burden
   # - desktop

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -48,6 +48,8 @@ packages_select_by_deps:
   - tf2_ros
   - tf2_sensor_msgs
   - tf2_tools
+  - ros_control
+  - ros_controllers
   
   # ## Only limited number of packages to reduce maintainer burden
   # - desktop


### PR DESCRIPTION
Bumping rebuild for `ros_control` and `ros_controllers` for aarch64 under python 3.9.

FYI: I've started to test RoboStack on a Raspberry Pi CM4 8Gb with bullseye arm64 for my robot. Will keep you posted how things go...