### PR TITLE
add swri-console to the rebuild list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,8 @@ conda config --set channel_priority strict
 6. `cp vinca_linux_64.yaml vinca.yaml` (replace with your platform as necessary)
 7. Modify `vinca.yaml` as you please, e.g. add new packages to be built.
 8. Run vinca to generate the recipe by executing `vinca --multiple`
-9. Copy the generated recipe to the current folder: `cp recipes/ros-noetic-XXX.yaml recipe.yaml` - note that at least one package needs to be (re)build for this folder to show up. See more info below.
-10. Build the recipe using boa: `boa build . -m ./.ci_support/conda_forge_pinnings.yaml -m ./conda_build_config.yaml`
+9. Move to the `recipes/ros-noetic-XXX/` folder to find the recipes that need to be (re)build. Note that at least one package needs to be (re)build for folder to show up.
+10. Build the recipe from the recipe folder using boa: `boa build . -m ../../.ci_support/conda_forge_pinnings.yaml -m ../../conda_build_config.yaml`
 
 # How does it work?
 - The `vinca.yaml` file specifies which packages should be built. 

--- a/patch/ros-noetic-rviz.patch
+++ b/patch/ros-noetic-rviz.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 038a4313..f9ca5ac8 100644
+index d623dd4e..0d1c07bb 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -102,10 +102,10 @@ if(APPLE)
+@@ -98,10 +98,10 @@ if(APPLE)
  endif()
  
  # Prefer newer vender-specific OpenGL library
@@ -17,7 +17,7 @@ index 038a4313..f9ca5ac8 100644
  
  set(CMAKE_AUTOMOC ON)
  
-@@ -218,7 +218,7 @@ catkin_package(
+@@ -214,7 +214,7 @@ catkin_package(
  
  #catkin_lint: ignore_once external_directory
  include_directories(src ${EXPORT_HEADER_DIR})
@@ -43,26 +43,8 @@ index 4b3c5b82..e714db0f 100644
  font "Liberation Sans"
  {
    type truetype
-diff --git a/src/python_bindings/sip/CMakeLists.txt b/src/python_bindings/sip/CMakeLists.txt
-index 847f75bc..9e5f8ba6 100644
---- a/src/python_bindings/sip/CMakeLists.txt
-+++ b/src/python_bindings/sip/CMakeLists.txt
-@@ -67,7 +67,12 @@ if(sip_helper_FOUND)
-     DEPENDENCIES rviz
-   )
-   if(APPLE)
--    set(rviz_sip_LIBRARY_FILE librviz_sip.so)
-+     # Okay-ish hack for now
-+     if(${SIP_VERSION} VERSION_GREATER_EQUAL "5.0.0")
-+       set(rviz_sip_LIBRARY_FILE "librviz_sip.cpython-${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}-darwin.so")
-+     else()
-+       set(rviz_sip_LIBRARY_FILE librviz_sip.so)
-+     endif()  
-   elseif(WIN32)
-     set(rviz_sip_LIBRARY_FILE librviz_sip.pyd)
-   else()
 diff --git a/src/rviz/ogre_helpers/render_system.cpp b/src/rviz/ogre_helpers/render_system.cpp
-index 34f46d6e..c802f776 100644
+index 4005f982..c0441de8 100644
 --- a/src/rviz/ogre_helpers/render_system.cpp
 +++ b/src/rviz/ogre_helpers/render_system.cpp
 @@ -159,9 +159,10 @@ void RenderSystem::setupDummyWindowId()

--- a/patch/ros-noetic-rviz.patch
+++ b/patch/ros-noetic-rviz.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d623dd4e..0d1c07bb 100644
+index 038a4313..f9ca5ac8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -98,10 +98,10 @@ if(APPLE)
+@@ -102,10 +102,10 @@ if(APPLE)
  endif()
  
  # Prefer newer vender-specific OpenGL library
@@ -17,7 +17,7 @@ index d623dd4e..0d1c07bb 100644
  
  set(CMAKE_AUTOMOC ON)
  
-@@ -214,7 +214,7 @@ catkin_package(
+@@ -218,7 +218,7 @@ catkin_package(
  
  #catkin_lint: ignore_once external_directory
  include_directories(src ${EXPORT_HEADER_DIR})
@@ -43,8 +43,26 @@ index 4b3c5b82..e714db0f 100644
  font "Liberation Sans"
  {
    type truetype
+diff --git a/src/python_bindings/sip/CMakeLists.txt b/src/python_bindings/sip/CMakeLists.txt
+index 847f75bc..9e5f8ba6 100644
+--- a/src/python_bindings/sip/CMakeLists.txt
++++ b/src/python_bindings/sip/CMakeLists.txt
+@@ -67,7 +67,12 @@ if(sip_helper_FOUND)
+     DEPENDENCIES rviz
+   )
+   if(APPLE)
+-    set(rviz_sip_LIBRARY_FILE librviz_sip.so)
++     # Okay-ish hack for now
++     if(${SIP_VERSION} VERSION_GREATER_EQUAL "5.0.0")
++       set(rviz_sip_LIBRARY_FILE "librviz_sip.cpython-${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}-darwin.so")
++     else()
++       set(rviz_sip_LIBRARY_FILE librviz_sip.so)
++     endif()  
+   elseif(WIN32)
+     set(rviz_sip_LIBRARY_FILE librviz_sip.pyd)
+   else()
 diff --git a/src/rviz/ogre_helpers/render_system.cpp b/src/rviz/ogre_helpers/render_system.cpp
-index 4005f982..c0441de8 100644
+index 34f46d6e..c802f776 100644
 --- a/src/rviz/ogre_helpers/render_system.cpp
 +++ b/src/rviz/ogre_helpers/render_system.cpp
 @@ -159,9 +159,10 @@ void RenderSystem::setupDummyWindowId()

--- a/patch/ros-noetic-rviz.patch
+++ b/patch/ros-noetic-rviz.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 038a4313..f9ca5ac8 100644
+index d623dd4e..0d1c07bb 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -102,10 +102,10 @@ if(APPLE)
+@@ -98,10 +98,10 @@ if(APPLE)
  endif()
  
  # Prefer newer vender-specific OpenGL library
@@ -17,7 +17,7 @@ index 038a4313..f9ca5ac8 100644
  
  set(CMAKE_AUTOMOC ON)
  
-@@ -218,7 +218,7 @@ catkin_package(
+@@ -214,7 +214,7 @@ catkin_package(
  
  #catkin_lint: ignore_once external_directory
  include_directories(src ${EXPORT_HEADER_DIR})
@@ -44,25 +44,25 @@ index 4b3c5b82..e714db0f 100644
  {
    type truetype
 diff --git a/src/python_bindings/sip/CMakeLists.txt b/src/python_bindings/sip/CMakeLists.txt
-index 847f75bc..9e5f8ba6 100644
+index efbb497b..7a2a60e6 100644
 --- a/src/python_bindings/sip/CMakeLists.txt
 +++ b/src/python_bindings/sip/CMakeLists.txt
-@@ -67,7 +67,12 @@ if(sip_helper_FOUND)
-     DEPENDENCIES rviz
-   )
-   if(APPLE)
+@@ -69,7 +69,12 @@ if(sip_helper_FOUND)
+   if(DEFINED PYTHON_EXTENSION_MODULE_SUFFIX)
+     set(rviz_sip_LIBRARY_FILE librviz_sip${PYTHON_EXTENSION_MODULE_SUFFIX})
+   elseif(APPLE)
 -    set(rviz_sip_LIBRARY_FILE librviz_sip.so)
-+     # Okay-ish hack for now
-+     if(${SIP_VERSION} VERSION_GREATER_EQUAL "5.0.0")
-+       set(rviz_sip_LIBRARY_FILE "librviz_sip.cpython-${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}-darwin.so")
-+     else()
-+       set(rviz_sip_LIBRARY_FILE librviz_sip.so)
-+     endif()  
++    # Okay-ish hack for now
++    if(${SIP_VERSION} VERSION_GREATER_EQUAL "5.0.0")
++      set(rviz_sip_LIBRARY_FILE "librviz_sip.cpython-${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}-darwin.so")
++    else()
++      set(rviz_sip_LIBRARY_FILE librviz_sip.so)
++    endif()
    elseif(WIN32)
      set(rviz_sip_LIBRARY_FILE librviz_sip.pyd)
    else()
 diff --git a/src/rviz/ogre_helpers/render_system.cpp b/src/rviz/ogre_helpers/render_system.cpp
-index 34f46d6e..c802f776 100644
+index 4005f982..c0441de8 100644
 --- a/src/rviz/ogre_helpers/render_system.cpp
 +++ b/src/rviz/ogre_helpers/render_system.cpp
 @@ -159,9 +159,10 @@ void RenderSystem::setupDummyWindowId()

--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -87,6 +87,8 @@ packages_select_by_deps:
   - plotjuggler
   - plotjuggler_ros
   - rosbridge_suite
+  - swri-console
+
 
   # - desktop
   # - amcl
@@ -169,7 +171,6 @@ packages_select_by_deps:
   # - swri-opencv-util
   # - swri-profiler
   # - swri-profiler-tools
-  # - swri-console
   # - swri-dbw-interface
   # - swri-math-util
   # - swri-nodelet


### PR DESCRIPTION
We would like to use the SwRI console again in our python 3.9 environments. 

I'm not sure if we also need the SwRI-console-util or any of the other packages but the ros package doesn't seem to depend on them so I tried it first like this. 