### PR TITLE
Improve contributing experience and instruction

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         if [[ -f "linux.yml" ]]; then
             git config --local user.email "action@github.com"
             git config --local user.name "GitHub Action"
-            git add .
+            git add . -f
             git commit -m "Add build files `date '+%Y-%m-%d-%H%M'`" -a
             remote_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             git push "${remote_repo}" HEAD:buildbranch_linux --follow-tags --force
@@ -51,7 +51,8 @@ jobs:
         if [[ -f "osx.yml" ]]; then
             git config --local user.email "action@github.com"
             git config --local user.name "GitHub Action"
-            git add .
+            git add . -f
+
             git commit -m "Add build files `date '+%Y-%m-%d-%H%M'`" -a
             remote_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             git push "${remote_repo}" HEAD:buildbranch_osx --follow-tags --force
@@ -76,7 +77,7 @@ jobs:
         if [[ -f "osx_arm64.yml" ]]; then
             git config --local user.email "action@github.com"
             git config --local user.name "GitHub Action"
-            git add .
+            git add . -f
             git commit -m "Add build files `date '+%Y-%m-%d-%H%M'`" -a
             remote_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             git push "${remote_repo}" HEAD:buildbranch_osx_arm64 --follow-tags --force
@@ -101,7 +102,7 @@ jobs:
         if [[ -f "win.yml" ]]; then
             git config --local user.email "action@github.com"
             git config --local user.name "GitHub Action"
-            git add .
+            git add . -f
             git commit -m "Add build files `date '+%Y-%m-%d-%H%M'`" -a
             remote_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             git push "${remote_repo}" HEAD:buildbranch_win --follow-tags --force
@@ -126,7 +127,7 @@ jobs:
         if [[ -f "linux_aarch64.yml" ]]; then
             git config --local user.email "action@github.com"
             git config --local user.name "GitHub Action"
-            git add .
+            git add . -f
             git commit -m "Add build files `date '+%Y-%m-%d-%H%M'`" -a
             remote_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             git push "${remote_repo}" HEAD:buildbranch_linux_aarch64 --follow-tags --force
@@ -152,7 +153,7 @@ jobs:
             mv linux_aarch64.yml .github/workflows/build_linux_aarch64.yml
             git config --local user.email "action@github.com"
             git config --local user.name "GitHub Action"
-            git add .
+            git add . -f
             git commit -m "Add build files `date '+%Y-%m-%d-%H%M'`" -a
             remote_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             git push "${remote_repo}" HEAD:buildbranch_linux_aarch64 --follow-tags --force

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+vinca.yaml
+recipes/
+*.bat
+*.sh
+*.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,13 +28,13 @@ Sometimes, it may be required to patch the packages. An example of how to do so 
 2. `cd ros-noetic`
 3. `conda env create -f env/robostackenv.yaml `
 4. Make a symbolic link between your platform's yaml and `vinca.yaml`. Examples
-* `ln vinca_linux_64.yaml vinca.yaml` 
-* `ln vinca_osx.yaml vinca.yaml`
+* `ln -s vinca_linux_64.yaml vinca.yaml` 
+* `ln -s vinca_osx.yaml vinca.yaml`
 * `mklink vinca.yaml vinca_win.yaml`
-5. Modify your environments yaml as you please, e.g. add new packages to be built.
+5. Modify your platform's yaml as you please, e.g. add new packages to be built.
 6. Run vinca to generate the recipe by executing `vinca --multiple`
-7. Move to the `recipes` folder to find the recipes that need to be (re)build. Note that at least one package needs to be (re)build for folder to show up.
-8. Build the recipe from the recipe folder using boa: `boa build . -m ../.ci_support/conda_forge_pinnings.yaml -m ../conda_build_config.yaml`
+7. Move to the `recipes` folder to find the recipes that need to be (re)build: `cd recipes`. Note that at least one package needs to be (re)build for folder to show up.
+8. Build the recipes from within the `recipes` folder using boa: `boa build . -m ../.ci_support/conda_forge_pinnings.yaml -m ../conda_build_config.yaml`
 
 # How does it work?
 - The `vinca.yaml` file specifies which packages should be built. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,27 +24,17 @@ Sometimes, it may be required to patch the packages. An example of how to do so 
 
 # Testing changes locally
 
-1. Create a new conda environment and add the conda-forge and robostack channels:
-```
-conda create -n robostackenv python=3.9
-conda activate robostackenv
-conda config --append channels defaults
-conda config --add channels conda-forge
-conda config --add channels robostack
-conda config --set channel_priority strict
-```
-2. Install some dependencies: `conda install pip conda-build anaconda-client mamba conda catkin_pkg ruamel.yaml rosdistro empy networkx requests boa`
-3. Install vinca: `pip install git+https://github.com/RoboStack/vinca.git@master --no-deps`
-4. Clone this repo: `git clone https://github.com/RoboStack/ros-noetic.git`
-5. `cd ros-noetic`
-6. Make a symbolic link between your platform's yaml and `vinca.yaml`. Examples
+1. Clone this repo: `git clone https://github.com/RoboStack/ros-noetic.git`
+2. `cd ros-noetic`
+3. `conda env create -f env/robostackenv.yaml `
+4. Make a symbolic link between your platform's yaml and `vinca.yaml`. Examples
 * `ln vinca_linux_64.yaml vinca.yaml` 
 * `ln vinca_osx.yaml vinca.yaml`
 * `mklink vinca.yaml vinca_win.yaml`
-7. Modify your environments yaml as you please, e.g. add new packages to be built.
-8. Run vinca to generate the recipe by executing `vinca --multiple`
-9. Move to the `recipes` folder to find the recipes that need to be (re)build. Note that at least one package needs to be (re)build for folder to show up.
-10. Build the recipe from the recipe folder using boa: `boa build . -m ../.ci_support/conda_forge_pinnings.yaml -m ../conda_build_config.yaml`
+5. Modify your environments yaml as you please, e.g. add new packages to be built.
+6. Run vinca to generate the recipe by executing `vinca --multiple`
+7. Move to the `recipes` folder to find the recipes that need to be (re)build. Note that at least one package needs to be (re)build for folder to show up.
+8. Build the recipe from the recipe folder using boa: `boa build . -m ../.ci_support/conda_forge_pinnings.yaml -m ../conda_build_config.yaml`
 
 # How does it work?
 - The `vinca.yaml` file specifies which packages should be built. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,14 @@ conda config --set channel_priority strict
 3. Install vinca: `pip install git+https://github.com/RoboStack/vinca.git@master --no-deps`
 4. Clone this repo: `git clone https://github.com/RoboStack/ros-noetic.git`
 5. `cd ros-noetic`
-6. `cp vinca_linux_64.yaml vinca.yaml` (replace with your platform as necessary)
-7. Modify `vinca.yaml` as you please, e.g. add new packages to be built.
+6. Make a symbolic link between your platform's yaml and `vinca.yaml`. Examples
+* `ln vinca_linux_64.yaml vinca.yaml` 
+* `ln vinca_osx.yaml vinca.yaml`
+* `mklink vinca.yaml vinca_win.yaml`
+7. Modify your environments yaml as you please, e.g. add new packages to be built.
 8. Run vinca to generate the recipe by executing `vinca --multiple`
-9. Move to the `recipes/ros-noetic-XXX/` folder to find the recipes that need to be (re)build. Note that at least one package needs to be (re)build for folder to show up.
-10. Build the recipe from the recipe folder using boa: `boa build . -m ../../.ci_support/conda_forge_pinnings.yaml -m ../../conda_build_config.yaml`
+9. Move to the `recipes` folder to find the recipes that need to be (re)build. Note that at least one package needs to be (re)build for folder to show up.
+10. Build the recipe from the recipe folder using boa: `boa build . -m ../.ci_support/conda_forge_pinnings.yaml -m ../conda_build_config.yaml`
 
 # How does it work?
 - The `vinca.yaml` file specifies which packages should be built. 

--- a/env/robostackenv.yaml
+++ b/env/robostackenv.yaml
@@ -1,6 +1,5 @@
 name: robostackenv
 channels:
-- defaults
 - robostack
 - conda-forge
 dependencies:

--- a/env/robostackenv.yaml
+++ b/env/robostackenv.yaml
@@ -1,0 +1,21 @@
+name: robostackenv
+channels:
+- defaults
+- robostack
+- conda-forge
+dependencies:
+- python=3.9
+- conda-build
+- anaconda-client
+- mamba
+- conda
+- catkin_pkg
+- ruamel.yaml
+- rosdistro
+- empy
+- networkx
+- requests
+- boa
+- pip
+- pip:
+  - git+https://github.com/RoboStack/vinca.git@master


### PR DESCRIPTION
gitignored blanketly .sh and .bat files generated during build. This should be expanded to include files generated on other OS's if moving them to a dedicated build directory is too difficult.

Want to make a conda env file to specify the contributing environment instead of all the commands, waiting to hear back on if owners agree.