### PR TITLE
Add -DNOGDI to Windows build of RViz

### DIFF
--- a/patch/ros-noetic-rviz.patch
+++ b/patch/ros-noetic-rviz.patch
@@ -1,4 +1,21 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d623dd4e7..cd195e488 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,11 @@
+ cmake_minimum_required(VERSION 3.0.2)
+ project(rviz)
+ 
++## Restrict Windows header namespace usage
++if(WIN32)
++  add_definitions(-DNOGDI)
++endif()
++
+ if (POLICY CMP0042)
+   cmake_policy(SET CMP0042 NEW)
+ endif()
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
 index d623dd4e..0d1c07bb 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt


### PR DESCRIPTION
To avoid https://github.com/RoboStack/ros-noetic/pull/295#issuecomment-1281525978, see https://github.com/ros-industrial/abb_robot_driver/issues/17#issuecomment-1126020610 .

In theory we should set it via `target_compile_definitions(<lib> PUBLIC NOGDI)` to the specific library that uses `ERROR` in its header to make sure that the definition is correctly propagated to downstream libraries, but for the time being we can try this simpler build.