### PR TITLE
Trigger build for handeye on linux 64

### DIFF
--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -89,6 +89,7 @@ packages_select_by_deps:
   - rosbridge_suite
   - swri-console
   - panda_moveit_config
+  - handeye
 
   # - desktop
   # - amcl
@@ -738,7 +739,6 @@ packages_select_by_deps:
   # - grasping-msgs
   # - grid-map-costmap-2d
   # - grid-map-sdf
-  # - handeye
   # - hector-gazebo-thermal-camera
   # - hector-gazebo-worlds
   # - hector-imu-attitude-to-tf


### PR DESCRIPTION
Handeye is currently only build for the `ros-distro-mutex-0.2` and I would like it to build for the `ros-distro-mutex-0.3`