### PR TITLE
fix `.cirun.yml` config to add labels

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -6,5 +6,5 @@ runners:
     machine_image: ami-00dace5a405a9887e
     #machine_image: ami-0229f8cfc24033d05
     preemptible: false
-    workflow: .github/workflows/build_linux_aarch64.yml
-    count: 1
+    labels:
+      - cirun-linux-aarch64


### PR DESCRIPTION
I see none of the jobs are running on this repository: https://github.com/RoboStack/ros-noetic/actions/runs/3985448347

This is due to the missing labels in the `.cirun.yml` file. The runners are created but without matching labels, which makes them orphan and useless. This PR fixes this and also removed deprecated `workflow` and `count` params.

cc @Tobias-Fischer @wolfv 
