### PR TITLE
Add moveit-servo for linux_64

### DIFF
--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -42,6 +42,7 @@ packages_select_by_deps:
   - ros-babel-fish
   - ros-babel-fish-test-msgs
   - moveit_visual_tools
+  - moveit-servo
   - rviz_visual_tools
 
   # - desktop
@@ -520,7 +521,6 @@ packages_select_by_deps:
   # - monocam-settler
   # - move-base-flex
   # - moveit-resources-prbt-ikfast-manipulator-plugin
-  # - moveit-servo
   # - nav-2d-utils
   # - nav-core2
   # - nav-grid-iterators


### PR DESCRIPTION
Trying to resolve the following error (doesn't exist in `robostack-staging` channel):
```bash
$ mamba install ros-noetic-moveit-servo
...
Could not solve for environment specs
The following package could not be installed
└─ ros-noetic-moveit-servo   does not exist (perhaps a typo or a missing channel).
```

Using `robostack` channel:
```bash
$ mamba install -c robostack ros-noetic-moveit-servo
...
Invalid spec, no package name found: NULL>

# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "/home/eliotx/miniconda3/lib/python3.10/site-packages/conda/exception
s.py", line 1132, in __call__
        return func(*args, **kwargs)
      File "/home/eliotx/miniconda3/lib/python3.10/site-packages/mamba/mamba.py"
, line 941, in exception_converter
        raise e
      File "/home/eliotx/miniconda3/lib/python3.10/site-packages/mamba/mamba.py"
, line 934, in exception_converter
        exit_code = _wrapped_main(*args, **kwargs)
      File "/home/eliotx/miniconda3/lib/python3.10/site-packages/mamba/mamba.py"
, line 892, in _wrapped_main
        result = do_call(parsed_args, p)
      File "/home/eliotx/miniconda3/lib/python3.10/site-packages/mamba/mamba.py"
, line 754, in do_call
        exit_code = install(args, parser, "install")
      File "/home/eliotx/miniconda3/lib/python3.10/site-packages/mamba/mamba.py"
, line 560, in install
        print(solver.explain_problems())
    RuntimeError: Invalid spec, no package name found: NULL>
```
