### PR TITLE
Added festival TTS conda packages.

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -71,6 +71,8 @@ eigen:
   conda: [eigen]
 emacs:
   conda: [emacs]
+festival:
+  conda: [festival, festvox-kallpc16k]
 ffmpeg:
   conda: [ffmpeg]
 flac:

--- a/robostack.yaml
+++ b/robostack.yaml
@@ -71,6 +71,8 @@ eigen:
   robostack: [eigen]
 emacs:
   robostack: [emacs]
+festival:
+  robostack: [festival, festvox-kallpc16k]
 ffmpeg:
   robostack: [ffmpeg]
 flac:


### PR DESCRIPTION
Enables actually using sound_play node added in #332 .

On most systems, other libraries are needed, but it doesn't make sense to make them dependencies of the festival package:

* On Ubuntu, `alsa-plugins` is needed.
* On Arch (SteamDeck), this hack is needed: `ln -s /usr/lib/alsa-lib/libasound_module_pcm_pipewire.so /home/deck/mambaforge/envs/ros_env/lib/alsa-lib/libasound_module_pcm_pipewire.so` (there is no pipewire package on conda, but as Arch is a rolling distro, the versions from conda and Arch are not too distant, so this hack works).