### PR TITLE
Enable build of magnetometer_compass on aarch64 linux

### DIFF
--- a/.github/testpr_environment.yml
+++ b/.github/testpr_environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - rospkg
   - catkin_pkg >=0.4.16
-  - ruamel.yaml >=0.16.6
+  - ruamel.yaml >=0.16.6,<0.18.0
   - rosdistro >=0.8.0
   - empy >=3.3.4
   - mamba

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -40,7 +40,7 @@ packages_select_by_deps:
   - cras_relative_positional_controller  # maintainer peci1
   - cras_msgs  # maintainer peci1
   - compass_msgs  # maintainer peci1
-  # does not work on aarch64 (yet) # - magnetometer_compass  # maintainer peci1
+  - magnetometer_compass  # maintainer peci1; does not work on aarch64 in pull requests due to cross-compiling (but okay on master branch)
   - electronic_io_msgs  # maintainer peci1
   - electronic_io  # maintainer peci1
   - point_cloud_color  # maintainer peci1


### PR DESCRIPTION
> If you need magnetometer_compass on aarch64, the build would likely succeed on the main branch as there we build natively instead of cross-compiling (as in PRs).

_Originally posted by @Tobias-Fischer in https://github.com/RoboStack/ros-noetic/issues/422#issuecomment-1778140691_

Thanks for the explanation, trying it in this PR.