### PR TITLE
Be more verbose about commented-out packages in vinca files.

### DIFF
--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -36,6 +36,11 @@ skip_existing:
   # - https://conda.anaconda.org/robostack/
   - https://conda.anaconda.org/robostack-staging/
 
+# This list contains lots of commented-out package names. That is okay.
+# Not all packages need to be rebuilt with every pull request.
+# Do not be afraid if you see a package commented out after some time - it just means it is not being built now.
+# For sure it will be uncommented and built with next full rebuild. Full rebuilds happen occasionally (few times a year).
+# The list of all maintained packages is at https://robostack.github.io/noetic.html .
 packages_select_by_deps:
   - cras_cpp_common  # maintainer peci1
   - cras_py_common  # maintainer peci1

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -27,6 +27,11 @@ skip_existing:
   # - https://conda.anaconda.org/robostack/
   - https://conda.anaconda.org/robostack-staging/
 
+# This list contains lots of commented-out package names. That is okay.
+# Not all packages need to be rebuilt with every pull request.
+# Do not be afraid if you see a package commented out after some time - it just means it is not being built now.
+# For sure it will be uncommented and built with next full rebuild. Full rebuilds happen occasionally (few times a year).
+# The list of all maintained packages is at https://robostack.github.io/noetic.html .
 packages_select_by_deps:
   - cras_cpp_common  # maintainer peci1
   - cras_py_common  # maintainer peci1

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -28,6 +28,11 @@ skip_existing:
   # - https://conda.anaconda.org/robostack/
   - https://conda.anaconda.org/robostack-staging/
 
+# This list contains lots of commented-out package names. That is okay.
+# Not all packages need to be rebuilt with every pull request.
+# Do not be afraid if you see a package commented out after some time - it just means it is not being built now.
+# For sure it will be uncommented and built with next full rebuild. Full rebuilds happen occasionally (few times a year).
+# The list of all maintained packages is at https://robostack.github.io/noetic.html .
 packages_select_by_deps:
   - rospack
   - microstrain-inertial-driver

--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -30,6 +30,11 @@ skip_existing:
   - https://conda.anaconda.org/robostack-staging/
   # - /Users/fischert/mambaforge/conda-bld
 
+# This list contains lots of commented-out package names. That is okay.
+# Not all packages need to be rebuilt with every pull request.
+# Do not be afraid if you see a package commented out after some time - it just means it is not being built now.
+# For sure it will be uncommented and built with next full rebuild. Full rebuilds happen occasionally (few times a year).
+# The list of all maintained packages is at https://robostack.github.io/noetic.html .
 packages_select_by_deps:
   ##
   #  TODO OSX-ARM64

--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -30,6 +30,11 @@ skip_existing:
   # - https://conda.anaconda.org/robostack/
   - https://conda.anaconda.org/robostack-staging/
 
+# This list contains lots of commented-out package names. That is okay.
+# Not all packages need to be rebuilt with every pull request.
+# Do not be afraid if you see a package commented out after some time - it just means it is not being built now.
+# For sure it will be uncommented and built with next full rebuild. Full rebuilds happen occasionally (few times a year).
+# The list of all maintained packages is at https://robostack.github.io/noetic.html .
 packages_select_by_deps:
   - actionlib
   - foxglove_bridge


### PR DESCRIPTION
As suggested in #420, I tried adding a few lines explaining that commented-out packages are not a problem.

It would be worth also saying that not all commented-out packages will be uncommented during full rebuilds. I see some "marker lines" (like `PREVIOUSLY SUPPORTED PACKAGES`) which probably denote packages that are no longer supported. But I don't know your workflow, so I'll let that one for you.

Personally, I'd like if unsupported packages disappeared from the vinca files completely. It might also make sense to alphabetize the lists for easier orientation.