### PR TITLE
Use libboost-* packages instead of deprecated boost and boost-cpp packages

### DIFF
--- a/additional_recipes/ros-distro-mutex/recipe.yaml
+++ b/additional_recipes/ros-distro-mutex/recipe.yaml
@@ -16,7 +16,6 @@ requirements:
   # This has to be synchronized with our current conda_build_config all the time :(
   # host:
   #   # values here should 
-  #   - boost-cpp
   #   - log4cxx
   #   - poco
   #   - pcl

--- a/conda.yaml
+++ b/conda.yaml
@@ -27,7 +27,7 @@ binutils:
 bison:
   conda: [bison]
 boost:
-  conda: [boost]
+  conda: [libboost-devel, libboost-python-devel]
 bullet:
   conda: [bullet]
 bzip2:
@@ -193,41 +193,41 @@ libabsl-dev:
 libblas-dev:
   conda: [libblas, libcblas]
 libboost-chrono-dev:
-  conda: [boost-cpp]
+  conda: [libboost-devel]
 libboost-date-time:
-  conda: [boost-cpp]
+  conda: [libboost]
 libboost-date-time-dev:
-  conda: [boost-cpp]
+  conda: [libboost-devel]
 libboost-dev:
-  conda: [boost-cpp]
+  conda: [libboost-devel]
 libboost-filesystem:
-  conda: [boost-cpp]
+  conda: [libboost]
 libboost-filesystem-dev:
-  conda: [boost-cpp]
+  conda: [libboost-devel]
 libboost-iostreams-dev:
-  conda: [boost-cpp]
+  conda: [libboost-devel]
 libboost-program-options:
-  conda: [boost-cpp]
+  conda: [libboost]
 libboost-program-options-dev:
-  conda: [boost-cpp]
+  conda: [libboost-devel]
 libboost-python:
-  conda: [boost]
+  conda: [libboost-python]
 libboost-python-dev:
-  conda: [boost]
+  conda: [libboost-python-devel]
 libboost-regex-dev:
-  conda: [boost-cpp]
+  conda: [libboost-devel]
 libboost-serialization:
-  conda: [boost-cpp]
+  conda: [libboost]
 libboost-serialization-dev:
-  conda: [boost-cpp]
+  conda: [libboost-devel]
 libboost-system:
-  conda: [boost-cpp]
+  conda: [libboost]
 libboost-system-dev:
-  conda: [boost-cpp]
+  conda: [libboost-devel]
 libboost-thread:
-  conda: [boost-cpp]
+  conda: [libboost]
 libboost-thread-dev:
-  conda: [boost-cpp]
+  conda: [libboost-devel]
 libcairo2-dev:
   conda: [cairo]
 libcap-dev:

--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -77,8 +77,8 @@ ur_client_library:
 mqtt_bridge:
   add_run: ["inject", "msgpack-python", "paho-mqtt", "pymongo"]
 mrpt2:
-  add_host:  ["tinyxml2", "boost-cpp", "jsoncpp", "gtest", "boost", "libdc1394", "xorg-libxcomposite", "ros-noetic-octomap", "libftdi"]
-  add_run:   ["tinyxml2", "boost-cpp", "jsoncpp", "gtest", "boost", "libdc1394", "xorg-libxcomposite", "ros-noetic-octomap", "libftdi"]
+  add_host:  ["tinyxml2", "libboost-devel", "jsoncpp", "gtest", "libboost-python-devel", "libdc1394", "xorg-libxcomposite", "ros-noetic-octomap", "libftdi"]
+  add_run:   ["tinyxml2", "libboost-devel", "jsoncpp", "gtest", "libboost-python-devel", "libdc1394", "xorg-libxcomposite", "ros-noetic-octomap", "libftdi"]
   add_build: [{"sel(linux)": "{{ cdt('libxcomposite-devel') }}"}]
 image_view:
   add_host: ["REQUIRE_OPENGL"]

--- a/robostack.yaml
+++ b/robostack.yaml
@@ -34,7 +34,7 @@ binutils:
 bison:
   robostack: [bison]
 boost:
-  robostack: [boost]
+  robostack: [libboost-devel, libboost-python-devel]
 bullet:
   robostack: [bullet]
 bzip2:
@@ -185,45 +185,45 @@ libabsl-dev:
 libblas-dev:
   robostack: [libblas, libcblas]
 libboost-chrono-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-date-time:
-  robostack: [boost-cpp]
+  robostack: [libboost]
 libboost-date-time-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-filesystem:
-  robostack: [boost-cpp]
+  robostack: [libboost]
 libboost-filesystem-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-iostreams-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-program-options:
-  robostack: [boost-cpp]
+  robostack: [libboost]
 libboost-program-options-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-python:
-  robostack: [boost]
+  robostack: [libboost-python]
 libboost-python-dev:
-  robostack: [boost]
+  robostack: [libboost-python-devel]
 libboost-random:
-  robostack: [boost-cpp]
+  robostack: [libboost]
 libboost-random-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-regex-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-serialization:
-  robostack: [boost-cpp]
+  robostack: [libboost]
 libboost-serialization-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-system:
-  robostack: [boost-cpp]
+  robostack: [libboost]
 libboost-system-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-thread:
-  robostack: [boost-cpp]
+  robostack: [libboost]
 libboost-thread-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libcairo2-dev:
   robostack: [cairo]
 libcap-dev:

--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -6,7 +6,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-build_number: 15
+build_number: 16
 
 # Ignore all dependencies of selected packages
 skip_all_deps: false
@@ -49,77 +49,77 @@ packages_select_by_deps:
   - realsense2-description
   
   - desktop
-  - rqt-gui
-  - catkin
-  - teleop_twist_keyboard
-  - perception_pcl
-  - rosbridge_suite
-  - rviz
-  - robot_localization
-  - amcl
-  - map-server
-  - move-base
-  # - gmapping
-  - fcl
-  - desktop_full
-  - moveit
-  - kdl-parser-py
-  - imu-tools
-  - rqt-controller-manager
-  - rosserial
-  - rosserial-server
-  - rosserial-python
-  - rosserial-msgs
-  - rosserial-windows
-  - rosserial-client
-  - hector-map-tools
-  - hector-nav-msgs
-  - hector-trajectory-server
-  - radar-msgs
-  - geometry2
-  - tf2
-  - tf2_bullet
-  - tf2_eigen
-  - tf2_geometry_msgs
-  - tf2_kdl
-  - tf2_msgs
-  - tf2_py
-  - tf2_ros
-  - tf2_sensor_msgs
-  - tf2_tools
-  - gps-common
-  - pcl-ros
-  - pcl-conversions
-  - velodyne-simulator
+  # - rqt-gui
+  # - catkin
+  # - teleop_twist_keyboard
+  # - perception_pcl
+  # - rosbridge_suite
+  # - rviz
+  # - robot_localization
+  # - amcl
+  # - map-server
+  # - move-base
+  # # - gmapping
+  # - fcl
+  # - desktop_full
+  # - moveit
+  # - kdl-parser-py
+  # - imu-tools
+  # - rqt-controller-manager
+  # - rosserial
+  # - rosserial-server
+  # - rosserial-python
+  # - rosserial-msgs
+  # - rosserial-windows
+  # - rosserial-client
+  # - hector-map-tools
+  # - hector-nav-msgs
+  # - hector-trajectory-server
+  # - radar-msgs
+  # - geometry2
+  # - tf2
+  # - tf2_bullet
+  # - tf2_eigen
+  # - tf2_geometry_msgs
+  # - tf2_kdl
+  # - tf2_msgs
+  # - tf2_py
+  # - tf2_ros
+  # - tf2_sensor_msgs
+  # - tf2_tools
+  # - gps-common
+  # - pcl-ros
+  # - pcl-conversions
+  # - velodyne-simulator
 
-  - gazebo-dev
-  - gazebo-ros
-  - gazebo-ros-control
-  - gazebo-plugins
-  - effort-controllers
-  - velocity-controllers
-  - joy
+  # - gazebo-dev
+  # - gazebo-ros
+  # - gazebo-ros-control
+  # - gazebo-plugins
+  # - effort-controllers
+  # - velocity-controllers
+  # - joy
 
-  - lms1xx
-  - controller-manager
-  - interactive_marker_twist_server
-  - diff-drive-controller
-  - joint-state-controller
-  - robot-localization
-  - teleop-twist-joy
-  - twist-mux
-  - pointgrey-camera-description
-  - nmea-msgs
-  - geometry-msgs
-  - nmea-navsat-driver
-  - imu-filter-madgwick
-  - ros_numpy
-  - teb-local-planner
-  - turtlebot3
-  - turtlebot3-fake
-  - plotjuggler_ros
-  - plotjuggler
-  - rosserial-arduino
+  # - lms1xx
+  # - controller-manager
+  # - interactive_marker_twist_server
+  # - diff-drive-controller
+  # - joint-state-controller
+  # - robot-localization
+  # - teleop-twist-joy
+  # - twist-mux
+  # - pointgrey-camera-description
+  # - nmea-msgs
+  # - geometry-msgs
+  # - nmea-navsat-driver
+  # - imu-filter-madgwick
+  # - ros_numpy
+  # - teb-local-planner
+  # - turtlebot3
+  # - turtlebot3-fake
+  # - plotjuggler_ros
+  # - plotjuggler
+  # - rosserial-arduino
 
   ##
   ## PREVIOUSLY SUPPORTED PACKAGES, NOW NOT PACKAGED ANYMORE UNTIL REQUESTED


### PR DESCRIPTION
As reported in https://github.com/RoboStack/ros-noetic/issues/448#issuecomment-1962127319, the use of deprecated packages that were not pinned in pinnings was basically causing the pinning to be ignored.