### PR TITLE
Add libprotobuf and libabseil dependency to any package that depends on Gazebo

### DIFF
--- a/robostack.yaml
+++ b/robostack.yaml
@@ -100,11 +100,11 @@ g++-static:
 gawk:
   robostack: [gawk]
 gazebo:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 gazebo11:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 gazebo9:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 geographiclib:
   robostack: [geographiclib-cpp]
 geographiclib-tools:
@@ -264,9 +264,9 @@ libfreetype6-dev:
 libftdi-dev:
   robostack: [libftdi, libusb]
 libgazebo11-dev:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 libgazebo9-dev:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 libgdal-dev:
   robostack: [libgdal]
 libgeos++-dev:


### PR DESCRIPTION
Not a final solution for https://github.com/RoboStack/ros-noetic/issues/459#issuecomment-2039873991, but something that could mitigate the problem as protobuf and abseil are two of the most frequently updated libraries.

xref: https://github.com/conda-forge/gazebo-feedstock/issues/107 