### PR TITLE
Add libabseil and libprotobuf to the run_constrained of ros-distro-mutex

### DIFF
--- a/additional_recipes/ros-distro-mutex/recipe.yaml
+++ b/additional_recipes/ros-distro-mutex/recipe.yaml
@@ -3,7 +3,7 @@ package:
   version: 0.5.0
 
 build:
-  number: 4
+  number: 5
   string: noetic
   run_exports:
     - "{{ pin_subpackage('ros-distro-mutex', max_pin='x.x') }}"

--- a/additional_recipes/ros-distro-mutex/recipe.yaml
+++ b/additional_recipes/ros-distro-mutex/recipe.yaml
@@ -27,11 +27,15 @@ requirements:
   # values here should be applied from run_exports!
   # if the upstream package does not have run_exports
   # please change it in the conda_build_config.yaml!
+  # libabseil and libprotobuf added here as a workaround for
+  # https://github.com/RoboStack/ros-noetic/issues/459
   run_constrained:
     - libboost-devel 1.82
     - gazebo 11
     - ogre 1.10.12
     - libpqxx 7.8
+    - libabseil 20230802
+    - libprotobuf 4.24.3
 
 about:
   home: https://github.com/robostack/ros-noetic

--- a/conda.yaml
+++ b/conda.yaml
@@ -91,11 +91,11 @@ g++-static:
 gawk:
   conda: [gawk]
 gazebo:
-  conda: [gazebo]
+  conda: [gazebo, libprotobuf, libabseil]
 gazebo11:
-  conda: [gazebo]
+  conda: [gazebo, libprotobuf, libabseil]
 gazebo9:
-  conda: [gazebo]
+  conda: [gazebo, libprotobuf, libabseil]
 geographiclib:
   conda: [geographiclib-cpp]
 geographiclib-tools:
@@ -268,9 +268,9 @@ libfreetype6-dev:
 libftdi-dev:
   conda: [libftdi, libusb]
 libgazebo11-dev:
-  conda: [gazebo]
+  conda: [gazebo, libprotobuf, libabseil]
 libgazebo9-dev:
-  conda: [gazebo]
+  conda: [gazebo, libprotobuf, libabseil]
 libgdal-dev:
   conda: [libgdal]
 libgeos++-dev:

--- a/robostack.yaml
+++ b/robostack.yaml
@@ -100,11 +100,11 @@ g++-static:
 gawk:
   robostack: [gawk]
 gazebo:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 gazebo11:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 gazebo9:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 geographiclib:
   robostack: [geographiclib-cpp]
 geographiclib-tools:
@@ -264,9 +264,9 @@ libfreetype6-dev:
 libftdi-dev:
   robostack: [libftdi, libusb]
 libgazebo11-dev:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 libgazebo9-dev:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 libgdal-dev:
   robostack: [libgdal]
 libgeos++-dev:


### PR DESCRIPTION
Workaround for:
* https://github.com/RoboStack/ros-noetic/issues/459
* https://github.com/RoboStack/ros-noetic/issues/343
* https://github.com/RoboStack/ros-noetic/issues/454

@Tobias-Fischer we need to bump the build number, right?