### PR TITLE
Bump eigenpy to 3.5.0

### DIFF
--- a/additional_recipes/ros-noetic-eigenpy/recipe.yaml
+++ b/additional_recipes/ros-noetic-eigenpy/recipe.yaml
@@ -1,6 +1,6 @@
 package:
   name: ros-noetic-eigenpy
-  version: "3.1.0"
+  version: "3.5.0"
 
 build:
   number: 21
@@ -8,10 +8,10 @@ build:
 outputs:
   - package:
       name: ros-noetic-eigenpy
-      version: "3.1.0"
+      version: "3.5.0"
     build:
       run_exports:
         - "{{ pin_subpackage('ros-noetic-eigenpy', max_pin='x.x.x') }}"
     requirements:
       run:
-        - eigenpy 3.1.0
+        - eigenpy 3.5.0


### PR DESCRIPTION
Update the version of eigenpy for ros-noetic to a newest one i.e. 3.5.0