### PR TITLE
Add proper match * to ros-distro-mutex dependencies

### DIFF
--- a/additional_recipes/ros-distro-mutex/recipe.yaml
+++ b/additional_recipes/ros-distro-mutex/recipe.yaml
@@ -3,7 +3,7 @@ package:
   version: 0.5.0
 
 build:
-  number: 6
+  number: 7
   string: noetic
   run_exports:
     - "{{ pin_subpackage('ros-distro-mutex', max_pin='x.x') }}"
@@ -30,13 +30,13 @@ requirements:
   # libabseil and libprotobuf added here as a workaround for
   # https://github.com/RoboStack/ros-noetic/issues/459
   run_constrained:
-    - libboost-devel 1.82
-    - gazebo 11
-    - ogre 1.10.12
-    - libpqxx 7.8
+    - libboost-devel 1.82.*
+    - gazebo 11.*
+    - ogre 1.10.12.*
+    - libpqxx 7.8.*
     # Add those for next rebuild, needed for Gazebo
-    # - libabseil 20230802
-    # - libprotobuf 4.24.3
+    # - libabseil 20230802.*
+    # - libprotobuf 4.24.3.*
 
 about:
   home: https://github.com/robostack/ros-noetic


### PR DESCRIPTION
At some point in the past, `conda-build`/`boa` went from translating `gazebo 11` from `gazebo==11.*` to `gazebo==11.0.0`. I am not sure when this happened, but for sure it is better to be less ambiguous and clearly indicate that we are constraining just the versions indicated, not the one not indicated.

With a re-build of ros-distro-mutex this should fix https://github.com/RoboStack/ros-noetic/issues/475 .