### PR TITLE
misc: bump image_transport_plugins to 1.15.0-1

### DIFF
--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -72,6 +72,7 @@ packages_select_by_deps:
   - tf2_client  # maintainer peci1
   - tf_static_publisher  # maintainer peci1
   - movie_publisher  # maintainer peci1
+  - image_transport_plugins  # republish for 1.15.0-1
   - geometric_shapes
   - teleop-twist-keyboard
   - rosserial-client

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -64,6 +64,7 @@ packages_select_by_deps:
   - tf2_client  # maintainer peci1
   - tf_static_publisher  # maintainer peci1
   - movie_publisher  # maintainer peci1
+  - image_transport_plugins  # republish for 1.15.0-1
   - geometric_shapes
   - actionlib
   - ros-babel-fish


### PR DESCRIPTION
I am not completely sure if this is the correct way, but https://github.com/ros/rosdistro/pull/42174 was merged to the ros-distro. So I would like bump image transport plugins on robostack-staging to 1.15.0. 
