### PR TITLE
Add libdw-dev to rosdep

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -251,6 +251,11 @@ libcurl-dev:
   conda: [libcurl]
 libdc1394-dev:
   conda: [libdc1394]
+libdw-dev:
+  conda:
+    linux: [elfutils]
+    osx: []
+    win64: []
 libfcl-dev:
   conda: [fcl]
 libffi-dev:

--- a/robostack.yaml
+++ b/robostack.yaml
@@ -247,6 +247,11 @@ libcurl-dev:
   robostack: [libcurl]
 libdc1394-dev:
   robostack: [libdc1394]
+libdw-dev:
+  conda:
+    linux: [elfutils]
+    osx: []
+    win64: []
 libfcl-dev:
   robostack: [fcl]
 libffi-dev:


### PR DESCRIPTION
This will fix part of https://github.com/RoboStack/ros-noetic/issues/496#issuecomment-2406836536 .

Details:
* https://github.com/ros/rosdistro/blob/b6f3950d07b5ebd059d008ecedf9ce0a7652036c/rosdep/base.yaml#L3384
* https://conda-metadata-app.streamlit.app/?q=conda-forge%2Flinux-64%2Felfutils-0.191-h924a536_0.conda
* https://packages.ubuntu.com/noble/arm64/libdw-dev/filelist