### PR TITLE
Use boa branch of vinca

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,8 @@ jobs:
         python-version: '3.11' # Version range or exact version of a Python version to use, using SemVer's version range syntax
     - name: Install vinca
       run: |
-        pip install git+https://github.com/RoboStack/vinca.git
+        # Switch back to use main (i.e. default) branch once we switch to rattler-build
+        pip install git+https://github.com/RoboStack/vinca.git#boa
 
     - name: Generate recipes for linux-64
       run: |

--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -91,7 +91,8 @@ jobs:
       shell: bash -l {0}
       run: |
         # use no-deps for now, otherwise problems with ruamel.
-        pip install git+https://github.com/RoboStack/vinca.git --no-deps
+        # Switch back to use main (i.e. default) branch once we switch to rattler-build
+        pip install git+https://github.com/RoboStack/vinca.git#boa --no-deps
     # For some reason, the Strawberry perl's pkg-config is found
     # instead of the conda's one, so let's delete the /c/Strawberry directory
     - name: Debug pkg-config problem

--- a/env/robostackenv.yaml
+++ b/env/robostackenv.yaml
@@ -17,4 +17,5 @@ dependencies:
 - boa
 - pip
 - pip:
-  - git+https://github.com/RoboStack/vinca.git@master
+  # Switch back to use main (i.e. default) branch once we switch to rattler-build
+  - git+https://github.com/RoboStack/vinca.git@boa


### PR DESCRIPTION
I do not think it will work out of the box now, but by doing so then we can change the default branch of vinca (see https://github.com/RoboStack/vinca/pull/65).