### PR TITLE
Rebuild packages that link tinyxml2 with correct run_exports for tinyxml2 10.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -18,6 +18,8 @@ pyqtwebengine:
   - 5.15
 pyqtchart:
   - 5.15
+tinyxml2:
+  - 10.0
 
 cdt_name:
   - ${{ "cos7" if linux }}

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -4,3 +4,15 @@ desktop_full:
   build_number: 22
 rqt_common_plugins:
   build_number: 22
+rospack:
+  build_number: 22
+kdl_parser:
+  build_number: 22
+pluginlib:
+  build_number: 22
+rviz:
+  build_number: 22
+srdfdom:
+  build_number: 22
+urdf:
+  build_number: 22

--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -1215,3 +1215,4 @@ packages_select_by_deps:
 
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml
+

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -196,3 +196,4 @@ packages_select_by_deps:
 
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml
+

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -891,3 +891,4 @@ packages_select_by_deps:
 
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml
+

--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -167,3 +167,4 @@ packages_select_by_deps:
 
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml
+

--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -537,3 +537,4 @@ packages_select_by_deps:
 
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml
+


### PR DESCRIPTION
Mitigation for https://github.com/conda-forge/tinyxml2-feedstock/issues/16, I am not sure if the solver will prefer to bump the build version of all these packages or the minor version of tinyxml2, but without repodata patches I am afraid this is the only thing we can do unless we do a rebuild with tinyxml2==10.1.0 (that I would like to avoid, as there could be hidden dependencies on tinyxml2).

Do not merge until we have updated run_exports for tinyxml2==10.0.0, see https://github.com/conda-forge/tinyxml2-feedstock/pull/20 . The packages that I bumped were obtaining by checking which packages listed in https://index.ros.org/d/tinyxml2/ are also present in https://robostack.github.io/noetic.html .