### PR TITLE
Rebuild packages that were built with rattler-build 0.38.0

### DIFF
--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -5,14 +5,14 @@ desktop_full:
 rqt_common_plugins:
   build_number: 22
 rospack:
-  build_number: 22
+  build_number: 23
 kdl_parser:
-  build_number: 22
+  build_number: 23
 pluginlib:
-  build_number: 22
+  build_number: 23
 rviz:
-  build_number: 22
+  build_number: 23
 srdfdom:
-  build_number: 22
+  build_number: 23
 urdf:
-  build_number: 22
+  build_number: 23

--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -6,7 +6,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Reminder for next full rebuild, the next build number should be 23
+# Reminder for next full rebuild, the next build number should be 24
 build_number: 18
 
 # Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -6,7 +6,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Reminder for next full rebuild, the next build number should be 23
+# Reminder for next full rebuild, the next build number should be 24
 build_number: 12
 
 # Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -6,7 +6,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Reminder for next full rebuild, the next build number should be 23
+# Reminder for next full rebuild, the next build number should be 24
 build_number: 21
 
 # Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml

--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -6,7 +6,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Reminder for next full rebuild, the next build number should be 23
+# Reminder for next full rebuild, the next build number should be 24
 build_number: 9
 
 # Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml

--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -6,7 +6,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Reminder for next full rebuild, the next build number should be 23
+# Reminder for next full rebuild, the next build number should be 24
 build_number: 17
 
 # Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml


### PR DESCRIPTION
The PR https://github.com/RoboStack/ros-noetic/pull/514 was done to mitigate the ABI break of tinyxml2 10.1, but it actually created a code-signing related regression on osx-arm64 as rattler-build 0.38.0 was used (see https://github.com/conda-forge/rattler-build-feedstock/issues/149). This PR rebuilds exactly the same packages to use rattler-build 0.39.0 and solve the issue in https://github.com/RoboStack/ros-noetic/issues/516 .