### PR TITLE
Rebuild cv_bridge to fix missing link problem and pin CMake to 3.* to avoid CMake 4 breakage

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -20,6 +20,8 @@ pyqtchart:
   - 5.15
 tinyxml2:
   - 10.0
+cmake:
+  - 3.*
 
 cdt_name:
   - ${{ "cos7" if linux }}

--- a/patch/ros-noetic-cv-bridge.patch
+++ b/patch/ros-noetic-cv-bridge.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index ef804b91..4ef849c4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -3,28 +3,8 @@ project(cv_bridge)
+@@ -3,29 +3,8 @@ project(cv_bridge)
  
  find_package(catkin REQUIRED COMPONENTS rosconsole sensor_msgs)
  
@@ -28,7 +28,8 @@ index ef804b91..4ef849c4 100644
 -endif()
 -
 -find_package(OpenCV ${_opencv_version} REQUIRED
-+find_package(Boost REQUIRED CONFIG)
++find_package(Boost REQUIRED CONFIG COMPONENTS python)
++message(STATUS "Boost_LIBRARIES: ${Boost_LIBRARIES}")
 +find_package(OpenCV REQUIRED
    COMPONENTS
      opencv_core

--- a/patch/ros-noetic-cv-bridge.patch
+++ b/patch/ros-noetic-cv-bridge.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index ef804b91..4ef849c4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -3,29 +3,8 @@ project(cv_bridge)
+@@ -3,28 +3,8 @@ project(cv_bridge)
  
  find_package(catkin REQUIRED COMPONENTS rosconsole sensor_msgs)
  
@@ -29,7 +29,6 @@ index ef804b91..4ef849c4 100644
 -
 -find_package(OpenCV ${_opencv_version} REQUIRED
 +find_package(Boost REQUIRED CONFIG COMPONENTS python)
-+message(STATUS "Boost_LIBRARIES: ${Boost_LIBRARIES}")
 +find_package(OpenCV REQUIRED
    COMPONENTS
      opencv_core

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -16,3 +16,5 @@ srdfdom:
   build_number: 23
 urdf:
   build_number: 23
+cv_bridge:
+  build_number: 22

--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -1,6 +1,7 @@
 ros_distro: noetic
 mutex_package: ros-distro-mutex 0.6.* noetic_*
 
+
 # mapping for package keys
 conda_index:
   - robostack.yaml

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -1,6 +1,7 @@
 ros_distro: noetic
 mutex_package: ros-distro-mutex 0.6.* noetic_*
 
+
 # mapping for package keys
 conda_index:
   - robostack.yaml

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -14,6 +14,7 @@ build_number: 21
 # of all build numbers used in the target channel
 use_explicit_build_number: true
 
+
 # Ignore all dependencies of selected packages
 skip_all_deps: false
 

--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -1,6 +1,7 @@
 ros_distro: noetic
 mutex_package: ros-distro-mutex 0.6.* noetic_*
 
+
 # mapping for package keys
 conda_index:
   - robostack.yaml

--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -21,6 +21,7 @@ skip_all_deps: false
 # to match the selected build number for skipping
 full_rebuild: true
 
+
 packages_skip_by_deps:
   # - rviz
   # - diagnostic_updater


### PR DESCRIPTION
We debugged the problem https://github.com/RoboStack/ros-noetic/issues/525 of @JiahangWu on his laptop.

It turns out that just rebuilding the original repo (after a small boost-related fix) was working, and the problem of the robostack build version was that a link to `boost_python.dylib` was missing. It turns out that in our robostack patch we removed the request of the `python` components of Boost, and so `Boost_LIBRARIES` did not contained anymore the `boost_python` libraries. By adding back `COMPONENT python` to the `find_package(Boost)` call, everythings works fine, and indeed also rattler-build reports the correct link:

~~~
2025-04-03T13:14:36.7764600Z  │ │ [lib/python3.11/site-packages/cv_bridge/boost/cv_bridge_boost.so] links against:
2025-04-03T13:14:36.7765150Z  │ │  ├─ lib/libopencv_core.4.11.0.dylib (libopencv)
2025-04-03T13:14:36.7765470Z  │ │  ├─ lib/libcv_bridge.dylib (package)
2025-04-03T13:14:36.7765700Z  │ │  ├─ lib/libc++.1.0.dylib (libcxx)
2025-04-03T13:14:36.7765910Z  │ │  ├─ @rpath/cv_bridge_boost.so
2025-04-03T13:14:36.7766130Z  │ │  ├─ /usr/lib/libSystem.B.dylib (system)
2025-04-03T13:14:36.7766500Z  │ │  └─ lib/libboost_python311.dylib (libboost-python)
~~~

So this PR fixes https://github.com/RoboStack/ros-noetic/issues/525 .

I also pinned CMake to 3.* to avoid all the problems with projects defining `cmake_minimum_required(3.0)` for version earlier then 3.5 .