### PR TITLE
Added husky navigation to linux-64, aarch64, osx-arm64

### DIFF
--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -233,6 +233,7 @@ packages_select_by_deps:
   - rosfmt
   - husky-simulator
   - husky-desktop
+  - husky-navigation
   - lanelet2
 
   - ros-ign

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -161,6 +161,7 @@ packages_select_by_deps:
   - pid
   - husky-simulator
   - husky-desktop
+  - husky-navigation
   - tf2_web_republisher
 
   - velodyne

--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -162,6 +162,7 @@ packages_select_by_deps:
 
   - husky-simulator
   - husky-desktop
+  - husky-navigation
 
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml


### PR DESCRIPTION
Managed to miss the `ros-noetic-husky-navigation` package in my last pr...

Added. Let's see if it builds.