### PR TITLE
Fix macOS @rpath install-name id for ros_type_introspection

### DIFF
--- a/patch/ros-noetic-ros-type-introspection.patch
+++ b/patch/ros-noetic-ros-type-introspection.patch
@@ -2,12 +2,18 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 32fda3d..777de2c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
+@@ -9,7 +9,13 @@ find_package(catkin REQUIRED COMPONENTS
  )
  
  # Build flags
 -set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 ")
 +set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 ")
++
++# macOS: emit an @rpath install-name id for the built dylib. The old
++# cmake_minimum_required leaves policy CMP0042 = OLD, so without this the
++# library id is a bare 'libros_type_introspection.dylib' and @rpath resolution
++# fails for every consumer (e.g. the plotjuggler-ros plugins).
++set(CMAKE_MACOSX_RPATH ON)
  
  catkin_package(
     INCLUDE_DIRS include

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -70,3 +70,7 @@ apriltag:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
 apriltag_ros:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
+
+# Remove everything after this line on a full rebuild
+ros_type_introspection:
+  build_number: 25

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -5,7 +5,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Reminder for next full rebuild, the next build number should be 25
+# Reminder for next full rebuild, the next build number should be 26
 build_number: 24
 
 mutex_package:


### PR DESCRIPTION
Thanks for this great project! 


I tested loading a ros1 .bag into plotjuggler from a ros-noetic-plotjuggler-ros mamba install and got the following on macOS:

```
Loading compatible plugins from directory:  "/Users/myuser/miniforge3/envs/noetic/lib/plotjuggler"
"libDataLoadCSV.dylib is a DataLoader plugin"
"libDataLoadMCAP.dylib is a DataLoader plugin"
"libDataLoadULog.dylib is a DataLoader plugin"
"libDataStreamSample.dylib is a DataStreamer plugin"  ...disabled, unless option -t is used
"libDataStreamUDP.dylib is a DataStreamer plugin"
"libDataStreamWebSocket.dylib is a DataStreamer plugin"
"libDataStreamZMQ.dylib is a DataStreamer plugin"
"libParserDataTamer.dylib is a MessageParser plugin"
"libParserROS1.dylib is a MessageParser plugin"
"libParserROS2.dylib is a MessageParser plugin"
"libProtobufParser.dylib is a MessageParser plugin"
"libPublisherCSV.dylib is a StatePublisher plugin"
Type conversion already registered from type QString to type QwtText
"libToolboxFFT.dylib is a Toolbox plugin"
"libToolboxLuaEditor.dylib is a Toolbox plugin"
Type conversion already registered from type QString to type QwtText
"libToolboxQuaternion.dylib is a Toolbox plugin"
Number of plugins loaded:  14

Loading compatible plugins from directory:  "/Users/myuser/miniforge3/envs/noetic/lib/plotjuggler_ros"
"libDataLoadROS.dylib" :  "Cannot load library /Users/myuser/miniforge3/envs/noetic/lib/plotjuggler_ros/libDataLoadROS.dylib: (dlopen(/Users/myuser/miniforge3/envs/noetic/lib/plotjuggler_ros/libDataLoadROS.dylib, 0x0085): Library not loaded: libros_type_introspection.dylib\n  Referenced from: <0AE4A756-4FB6-3A89-9BE3-3FF7193A5BF6> /Users/myuser/miniforge3/envs/noetic/lib/plotjuggler_ros/libDataLoadROS.dylib\n  Reason: tried: 'libros_type_introspection.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibros_type_introspection.dylib' (no such file), 'libros_type_introspection.dylib' (no such file), '/Users/myuser/Sources/YY/XX_ros/libros_type_introspection.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/myuser/Sources/YY/XX_ros/libros_type_introspection.dylib' (no such file), '/Users/myuser/Sources/YY/XX_ros/libros_type_introspection.dylib' (no such file))"
"libDataStreamROS.dylib" :  "Cannot load library /Users/myuser/miniforge3/envs/noetic/lib/plotjuggler_ros/libDataStreamROS.dylib: (dlopen(/Users/myuser/miniforge3/envs/noetic/lib/plotjuggler_ros/libDataStreamROS.dylib, 0x0085): Library not loaded: libros_type_introspection.dylib\n  Referenced from: <3060550A-767D-34F1-B824-21105EB5A5C1> /Users/myuser/miniforge3/envs/noetic/lib/plotjuggler_ros/libDataStreamROS.dylib\n  Reason: tried: 'libros_type_introspection.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibros_type_introspection.dylib' (no such file), 'libros_type_introspection.dylib' (no such file), '/Users/myuser/Sources/YY/XX_ros/libros_type_introspection.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/myuser/Sources/YY/XX_ros/libros_type_introspection.dylib' (no such file), '/Users/myuser/Sources/YY/XX_ros/libros_type_introspection.dylib' (no such file))"
"libRosoutPublisher.dylib is a StatePublisher plugin"
"libRosTopicPublisher.dylib" :  "Cannot load library /Users/myuser/miniforge3/envs/noetic/lib/plotjuggler_ros/libRosTopicPublisher.dylib: (dlopen(/Users/myuser/miniforge3/envs/noetic/lib/plotjuggler_ros/libRosTopicPublisher.dylib, 0x0085): Library not loaded: libros_type_introspection.dylib\n  Referenced from: <046227DC-E270-3113-8A1E-24165C735005> /Users/myuser/miniforge3/envs/noetic/lib/plotjuggler_ros/libRosTopicPublisher.dylib\n  Reason: tried: 'libros_type_introspection.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibros_type_introspection.dylib' (no such file), 'libros_type_introspection.dylib' (no such file), '/Users/myuser/Sources/YY/XX_ros/libros_type_introspection.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/myuser/Sources/YY/XX_ros/libros_type_introspection.dylib' (no such file), '/Users/myuser/Sources/YY/XX_ros/libros_type_introspection.dylib' (no such file))"
Number of plugins loaded:  1

Loading compatible plugins from directory:  "/Users/myuser/Library/Application Support/PlotJuggler"
Number of plugins loaded:  0

```

Plotjuggler application opened as normal, but it did not allowing us to open a .bag

The dylib was built with a bare install-name id
('libros_type_introspection.dylib') because the old cmake_minimum_required leaves policy CMP0042 = OLD (MACOSX_RPATH off). Consumers then record the bare dependency name and dyld cannot resolve it from the environment lib dir, so all plotjuggler-ros plugins (DataLoadROS / DataStreamROS / RosTopicPublisher) fail to dlopen on osx-64 and osx-arm64 -- PlotJuggler ends up with no .bag loader.

Set CMAKE_MACOSX_RPATH ON so the library advertises an @rpath/libros_type_introspection.dylib install name. This fixes all consumers at the source. No-op on Linux/Windows.